### PR TITLE
AlwaysPrint feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Here is a configuration example with a proxy for intranet addresses, and another
 network:
   proxy:
     enable: true # allows disabling auto-config; enabled by default
+    alwaysPrint: false #allow the info log showing the proxy used every time a call is made
 
     # explicit list of proxy servers with settings
     servers:

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.orange.common</groupId>
 	<artifactId>spring-boot-autoconfigure-proxy</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<name>spring-boot-autoconfigure-proxy</name>
 	<description>Spring Boot AutoConfigure Proxy</description>
 

--- a/src/main/java/com/orange/common/springboot/autoconfigure/proxy/NetworkProxyAutoConfiguration.java
+++ b/src/main/java/com/orange/common/springboot/autoconfigure/proxy/NetworkProxyAutoConfiguration.java
@@ -38,7 +38,8 @@ public class NetworkProxyAutoConfiguration {
             LOGGER.info("Configuring proxies from Spring Boot configuration");
 
             // install proxy selector
-            ProxySelector.setDefault(MultiProxySelector.build(properties.getServers()));
+            ProxySelector.setDefault(MultiProxySelector.build(properties.getServers(),
+                    properties.isAlwaysPrint()));
 
             // set password authentication for every proxy that need one
             for (NetworkProxyProperties.ProxyServerConfig cfg : properties.getServers()) {

--- a/src/main/java/com/orange/common/springboot/autoconfigure/proxy/NetworkProxyProperties.java
+++ b/src/main/java/com/orange/common/springboot/autoconfigure/proxy/NetworkProxyProperties.java
@@ -22,6 +22,11 @@ public class NetworkProxyProperties implements Validator  {
     private boolean enabled = true;
 
     /**
+     * Whether to enable the print of the proxy used every time.
+     */
+    private boolean alwaysPrint = false;
+
+    /**
      * Explicit network proxy servers configuration
      */
     @Valid
@@ -43,10 +48,19 @@ public class NetworkProxyProperties implements Validator  {
         this.servers = servers;
     }
 
+    public boolean isAlwaysPrint() {
+        return alwaysPrint;
+    }
+
+    public void setAlwaysPrint(boolean alwaysPrint) {
+        this.alwaysPrint = alwaysPrint;
+    }
+
     @Override
     public String toString() {
         return "NetworkProxyProperties{" +
                 "enabled=" + enabled +
+                ", alwaysPrint= " +alwaysPrint +
                 ", servers=" + servers +
                 '}';
     }


### PR DESCRIPTION
allow the logger.info print to log the proxy used everytime the lib is used. this is useful as cloud logs are removed tipically every 30d so it is useful to know every feign call which proxy is used.
Could you please add the hacktoberfest-accepted label if it is good for you?